### PR TITLE
Completion of combat ring preset handling

### DIFF
--- a/ElvargServer/src/main/java/com/elvarg/game/content/presets/Presetables.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/content/presets/Presetables.java
@@ -283,26 +283,20 @@ public class Presetables {
 			return;
 		}
 
-		// Send valuable items in inventory/equipment to bank
 		boolean sent = false;
-		for (Item item : Misc.concat(player.getInventory().getCopiedItems(), player.getEquipment().getCopiedItems())) {
-			if (!item.isValid()) {
-				continue;
-			}
-			boolean spawnable = false;
-			for (int i : GameConstants.ALLOWED_SPAWNS) {
-				if (item.getId() == i) {
-					spawnable = true;
-					break;
+		if (!player.hasUsedPreset) {
+			// Player is loading preset for first time, bank all their items
+			for (Item item : Misc.concat(player.getInventory().getCopiedItems(), player.getEquipment().getCopiedItems())) {
+				if (!item.isValid()) {
+					continue;
 				}
-			}
-			if (!spawnable) {
+
 				player.getBank(Bank.getTabForItem(player, item.getId())).add(item, false);
 				sent = true;
 			}
-		}
-		if (sent) {
-			player.getPacketSender().sendMessage("The non-spawnable items you had on you have been sent to your bank.");
+			if (sent) {
+				player.getPacketSender().sendMessage("The items/equipment you had on you have been sent to your bank.");
+			}
 		}
 
 		player.getInventory().resetItems().refreshItems();
@@ -401,6 +395,7 @@ public class Presetables {
 		player.getPacketSender().sendConfig(711, PrayerHandler.canUse(player, PrayerData.RIGOUR, false) ? 1 : 0);
 		player.getPacketSender().sendConfig(713, PrayerHandler.canUse(player, PrayerData.AUGURY, false) ? 1 : 0);
 		player.resetAttributes();
+		player.hasUsedPreset = true;
 		player.getPacketSender().sendMessage("Preset loaded!");
 		player.getPacketSender().sendTotalExp(totalExp);
 

--- a/ElvargServer/src/main/java/com/elvarg/game/entity/impl/player/Player.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/entity/impl/player/Player.java
@@ -129,6 +129,7 @@ public class Player extends Mobile {
 	private Presetable currentPreset;
 	private Presetable[] presets = new Presetable[Presetables.MAX_PRESETS];
 	private boolean openPresetsOnDeath = true;
+	public boolean hasUsedPreset = false;
 
 	private String username;
 	private String password;

--- a/ElvargServer/src/main/java/com/elvarg/game/entity/impl/player/PlayerLoading.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/entity/impl/player/PlayerLoading.java
@@ -113,6 +113,10 @@ public class PlayerLoading {
                 player.setHasVengeance(reader.get("has-veng").getAsBoolean());
             }
 
+            if (reader.has("has-used-preset")) {
+                player.hasUsedPreset = reader.get("has-sued-preset").getAsBoolean();
+            }
+
             if (reader.has("last-veng")) {
                 player.getVengeanceTimer().start(reader.get("last-veng").getAsInt());
             }

--- a/ElvargServer/src/main/java/com/elvarg/game/entity/impl/player/PlayerLoading.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/entity/impl/player/PlayerLoading.java
@@ -114,7 +114,7 @@ public class PlayerLoading {
             }
 
             if (reader.has("has-used-preset")) {
-                player.hasUsedPreset = reader.get("has-sued-preset").getAsBoolean();
+                player.hasUsedPreset = reader.get("has-used-preset").getAsBoolean();
             }
 
             if (reader.has("last-veng")) {

--- a/ElvargServer/src/main/java/com/elvarg/game/entity/impl/player/PlayerSaving.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/entity/impl/player/PlayerSaving.java
@@ -50,6 +50,7 @@ public class PlayerSaving {
 			object.addProperty("rigour", player.isRigourUnlocked());
 			object.addProperty("augury", player.isAuguryUnlocked());
 			object.addProperty("has-veng", player.hasVengeance());
+			object.addProperty("has-used-preset", player.hasUsedPreset);
 			object.addProperty("last-veng", player.getVengeanceTimer().secondsRemaining());
 			object.addProperty("running", player.isRunning());
 			object.addProperty("run-energy", player.getRunEnergy());
@@ -91,7 +92,7 @@ public class PlayerSaving {
 			object.add("inventory", builder.toJsonTree(player.getInventory().getItems()));
 			object.add("equipment", builder.toJsonTree(player.getEquipment().getItems()));
 			object.add("appearance", builder.toJsonTree(player.getAppearance().getLook()));
-			object.add("skills", builder.toJsonTree(player.getSkillManager().getSkills()));
+			object.add("skills", builder.toJsonTree(player.getRealSkillManager().getSkills()));
 			object.add("quick-prayers", builder.toJsonTree(player.getQuickPrayers().getPrayers()));
 
 			object.add("friends", builder.toJsonTree(player.getRelations().getFriendList().toArray()));

--- a/ElvargServer/src/main/java/com/elvarg/game/model/areas/Area.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/model/areas/Area.java
@@ -35,6 +35,8 @@ public abstract class Area {
 
     public abstract boolean canDrink(Player player, int itemId);
 
+    public boolean canSpawn() { return false; }
+
     public boolean useTemporarySkills() { return false; }
 
     public abstract boolean dropItemsOnDeath(Player player, Optional<Player> killer);

--- a/ElvargServer/src/main/java/com/elvarg/game/model/areas/impl/CombatRingArea.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/model/areas/impl/CombatRingArea.java
@@ -2,6 +2,7 @@ package com.elvarg.game.model.areas.impl;
 import com.elvarg.game.entity.impl.Mobile;
 import com.elvarg.game.entity.impl.player.Player;
 import com.elvarg.game.model.Boundary;
+import com.elvarg.game.model.Flag;
 import com.elvarg.game.model.ForceMovement;
 import com.elvarg.game.model.Location;
 import com.elvarg.game.model.areas.Area;
@@ -23,7 +24,7 @@ public class CombatRingArea extends Area {
     public static void handleRingFirstClick(Player player) {
         int destX = 0, destY = 0, direction = 0;
 
-        if (player.getArea() instanceof CombatRingArea) {
+            if (player.getArea() instanceof CombatRingArea) {
 
             // Player is standing inside the Combat Ring
 
@@ -97,6 +98,13 @@ public class CombatRingArea extends Area {
                 .sendMessage("You leave the combat ring. You feel your skills restore to normal.");
 
         player.getRealSkillManager().refreshSkills();
+
+        if (player.hasUsedPreset) {
+            // If the player has used a preset, reset their items
+            player.getInventory().resetItems().refreshItems();
+            player.getEquipment().resetItems().refreshItems();
+            player.getUpdateFlag().flag(Flag.APPEARANCE);
+        }
     }
 
     @Override
@@ -153,6 +161,10 @@ public class CombatRingArea extends Area {
     @Override
     public void onPlayerRightClick(Player player, Player rightClicked, int option) {
 
+    }
+
+    public boolean canSpawn() {
+        return true;
     }
 
     public boolean useTemporarySkills() {

--- a/ElvargServer/src/main/java/com/elvarg/net/packet/impl/SpawnItemPacketListener.java
+++ b/ElvargServer/src/main/java/com/elvarg/net/packet/impl/SpawnItemPacketListener.java
@@ -25,8 +25,13 @@ public class SpawnItemPacketListener implements PacketExecutor {
         }
 
         // Check if player busy..
-        if (player.busy() || player.getArea() instanceof WildernessArea) {
-            player.getPacketSender().sendMessage("You cannot do that right now.");
+        if (player.busy() || player.getArea().canSpawn()) {
+            player.getPacketSender().sendMessage("You cannot spawn items right now.");
+            return;
+        }
+
+        if (!player.hasUsedPreset) {
+            player.getPacketSender().sendMessage("You must load a preset before you can spawn items.");
             return;
         }
 


### PR DESCRIPTION
-Tracking whether players have used a preset or not
-When players first use a preset, all current items/equipment go to bank
-When player leaves combat ring, either by dying or jumping out or logging out, items are cleared and levels are restoed
-Temporary levels (used in presets) wont ever be saved