### PR TITLE
Combat ring fixes

### DIFF
--- a/ElvargServer/src/main/java/com/elvarg/game/content/skill/SkillManager.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/content/skill/SkillManager.java
@@ -706,6 +706,14 @@ public class SkillManager {
 		this.skills = skills;
 	}
 
+	public void cloneSkills(SkillManager _skillManager) {
+		for (Skill skill : Skill.values()) {
+			int level = _skillManager.getCurrentLevel(skill);
+			this.setCurrentLevel(skill, level).setMaxLevel(skill, level)
+					.setExperience(skill, SkillManager.getExperienceForLevel(level));
+		}
+	}
+
 	public class Skills {
 
 		private int[] level, maxLevel, experience;

--- a/ElvargServer/src/main/java/com/elvarg/game/content/skill/SkillManager.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/content/skill/SkillManager.java
@@ -244,7 +244,7 @@ public class SkillManager {
 			player.getUpdateFlag().flag(Flag.APPEARANCE);
 		}
 		updateSkill(skill);
-		//PlayerSaving.save(player);
+		PlayerSaving.save(player);
 		return this;
 	}
 

--- a/ElvargServer/src/main/java/com/elvarg/game/content/skill/SkillManager.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/content/skill/SkillManager.java
@@ -16,6 +16,7 @@ import com.elvarg.game.content.skill.skillable.impl.Woodcutting;
 import com.elvarg.game.content.skill.skillable.impl.Woodcutting.Tree;
 import com.elvarg.game.entity.impl.object.GameObject;
 import com.elvarg.game.entity.impl.player.Player;
+import com.elvarg.game.entity.impl.player.PlayerSaving;
 import com.elvarg.game.model.Flag;
 import com.elvarg.game.model.Graphic;
 import com.elvarg.game.model.Item;
@@ -243,6 +244,7 @@ public class SkillManager {
 			player.getUpdateFlag().flag(Flag.APPEARANCE);
 		}
 		updateSkill(skill);
+		//PlayerSaving.save(player);
 		return this;
 	}
 

--- a/ElvargServer/src/main/java/com/elvarg/game/entity/impl/player/Player.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/entity/impl/player/Player.java
@@ -294,14 +294,13 @@ public class Player extends Mobile {
 		if (isDying) {
 			return this;
 		}
-
 		if (infiniteHealth) {
-			if (skillManager.getCurrentLevel(Skill.HITPOINTS) > hitpoints) {
+			if (getSkillManager().getCurrentLevel(Skill.HITPOINTS) > hitpoints) {
 				return this;
 			}
 		}
 
-		skillManager.setCurrentLevel(Skill.HITPOINTS, hitpoints);
+		getSkillManager().setCurrentLevel(Skill.HITPOINTS, hitpoints);
 		packetSender.sendSkill(Skill.HITPOINTS);
 		if (getHitpoints() <= 0 && !isDying)
 			appendDeath();
@@ -310,28 +309,28 @@ public class Player extends Mobile {
 
 	@Override
 	public void heal(int amount) {
-		int level = skillManager.getMaxLevel(Skill.HITPOINTS);
-		if ((skillManager.getCurrentLevel(Skill.HITPOINTS) + amount) >= level) {
+		int level = getSkillManager().getMaxLevel(Skill.HITPOINTS);
+		if ((getSkillManager().getCurrentLevel(Skill.HITPOINTS) + amount) >= level) {
 			setHitpoints(level);
 		} else {
-			setHitpoints(skillManager.getCurrentLevel(Skill.HITPOINTS) + amount);
+			setHitpoints(getSkillManager().getCurrentLevel(Skill.HITPOINTS) + amount);
 		}
 	}
 
 	@Override
 	public int getBaseAttack(CombatType type) {
 		if (type == CombatType.RANGED)
-			return skillManager.getCurrentLevel(Skill.RANGED);
+			return getSkillManager().getCurrentLevel(Skill.RANGED);
 		else if (type == CombatType.MAGIC)
-			return skillManager.getCurrentLevel(Skill.MAGIC);
-		return skillManager.getCurrentLevel(Skill.ATTACK);
+			return getSkillManager().getCurrentLevel(Skill.MAGIC);
+		return getSkillManager().getCurrentLevel(Skill.ATTACK);
 	}
 
 	@Override
 	public int getBaseDefence(CombatType type) {
 		if (type == CombatType.MAGIC)
-			return skillManager.getCurrentLevel(Skill.MAGIC);
-		return skillManager.getCurrentLevel(Skill.DEFENCE);
+			return getSkillManager().getCurrentLevel(Skill.MAGIC);
+		return getSkillManager().getCurrentLevel(Skill.DEFENCE);
 	}
 
 	@Override

--- a/ElvargServer/src/main/java/com/elvarg/game/model/areas/AreaManager.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/model/areas/AreaManager.java
@@ -50,11 +50,11 @@ public class AreaManager {
             }
         }
 
-
+        Area enteredArea = null;
         if (area == null) {
             area = get(position);
             if (area != null) {
-                area.enter(c);
+                enteredArea = area;
             }
         }
 
@@ -80,6 +80,11 @@ public class AreaManager {
 
         // Update area..
             c.setArea(area);
+
+        if (enteredArea != null) {
+            // Now that the player's area has been fully updated, call enter on the new area
+            enteredArea.enter(c);
+        }
 
         if (exitedArea != null) {
             // Now that the player's area has been fully updated, call leave on the previous one

--- a/ElvargServer/src/main/java/com/elvarg/game/model/areas/impl/CombatRingArea.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/model/areas/impl/CombatRingArea.java
@@ -94,6 +94,9 @@ public class CombatRingArea extends Area {
 
         player.getPacketSender().sendTabInterface(2, 31000 /* Presets on quest tab */);
 
+        player.getTempSkillManager().refreshSkills();
+        player.resetAttributes();
+
         // TODO: If there's no players in the combat ring, spawn a PVP bot
     }
 

--- a/ElvargServer/src/main/java/com/elvarg/game/model/areas/impl/CombatRingArea.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/model/areas/impl/CombatRingArea.java
@@ -94,6 +94,9 @@ public class CombatRingArea extends Area {
 
         player.getPacketSender().sendTabInterface(2, 31000 /* Presets on quest tab */);
 
+        // Copy the players current permanent skills to their temporary skills (so they dont appear to lose any levels)
+        player.getTempSkillManager().cloneSkills(player.getRealSkillManager());
+
         player.getTempSkillManager().refreshSkills();
         player.resetAttributes();
 


### PR DESCRIPTION
-When entering the ring, your permanent levels stayed, now temporary levels instantly appear
-Permanent levels are copied to temporary levels when entering combat ring
-Health was unlimited inside the combat ring
-When enter was called on an Area, player hadn't actually entered that area
